### PR TITLE
feat: 允许用户指定editor

### DIFF
--- a/components/index.vue
+++ b/components/index.vue
@@ -2,13 +2,18 @@
 import { ref, onMounted } from 'vue';
 import { Repl, ReplStore } from '@vue/repl';
 import { utoa } from './utils';
-import { defineClientComponent } from 'vitepress'
 import "@vue/repl/style.css";
+import CodeMirror from '@vue/repl/codemirror-editor'
+import Monaco from '@vue/repl/monaco-editor'
 const store = ref();
 const slots = defineSlots();
-const Monaco = defineClientComponent(() => {
-  return import('@vue/repl/monaco-editor')
-})
+const props = defineProps({
+  editor: {
+    type: String,
+    default: 'CodeMirror'
+  }
+});
+
 onMounted(() => {
   const children = slots.default();
   const code = children?.[0]?.children;
@@ -52,7 +57,7 @@ onMounted(() => {
       v-if="store"
       autoResize
       :store="store"
-      :editor="Monaco"
+      :editor="editor === 'CodeMirror' ? CodeMirror : Monaco"
       :showCompileOutput="true"
       :clearConsole="false"
     />

--- a/components/index.vue
+++ b/components/index.vue
@@ -2,9 +2,9 @@
 import { ref, onMounted } from 'vue';
 import { Repl, ReplStore } from '@vue/repl';
 import { utoa } from './utils';
+import { defineClientComponent } from 'vitepress'
 import "@vue/repl/style.css";
-import CodeMirror from '@vue/repl/codemirror-editor'
-import Monaco from '@vue/repl/monaco-editor'
+
 const store = ref();
 const slots = defineSlots();
 const props = defineProps({
@@ -12,6 +12,12 @@ const props = defineProps({
     type: String,
     default: 'CodeMirror'
   }
+});
+const Monaco = defineClientComponent(() => {
+  return import('@vue/repl/monaco-editor')
+});
+const CodeMirror = defineClientComponent(() => {
+  return import('@vue/repl/codemirror-editor')
 });
 
 onMounted(() => {

--- a/node/index.ts
+++ b/node/index.ts
@@ -1,14 +1,16 @@
 import MarkdownItContainer from 'markdown-it-container';
 export function VueReplMdPlugin(md: markdownit) {
   const defaultRender = md.renderer.rules.fence;
+  const pattern = /^playground\s*(CodeMirror|Monaco)?\s*$/i;
   md.use(MarkdownItContainer, 'playground', {
     validate: function(params: string) {
-      return params.trim().match(/^playground\s*(.*)$/);
+      return params.trim().match(pattern);
     },
     render: function (tokens: any[], idx: number) {
       if (tokens[idx].nesting === 1) {
-        const vueToken = tokens.find(e => e.info === 'vue');
-        return `<VuePlayground>${encodeURIComponent(vueToken.content)}\n`;
+        const editor = tokens[idx].info.toLowerCase().indexOf('monaco') > -1 ? 'Monaco' : 'CodeMirror';
+        const vueToken = tokens.slice(idx).find(e => e.info === 'vue');
+        return `<VuePlayground editor="${editor}">${encodeURIComponent(vueToken.content)}\n`;
       } else {
         // closing tag
         return '</VuePlayground>\n';


### PR DESCRIPTION
因为默认Monaco对暗黑模式的样式支持不好，导致在vitepress暗黑模式下的editor仍然是白色的，所以我想改成codemirror

还是支持用户能够指定editor比较好。